### PR TITLE
remove deepcopy of MessageIndex

### DIFF
--- a/src/messages.jl
+++ b/src/messages.jl
@@ -280,8 +280,7 @@ function filter_messages(mindexs::Vector{<:MessageIndex}, k::AbstractString, v)
 end
 
 
-function filter_messages(mindexs::Vector{<:MessageIndex}; query...)
-    ms = deepcopy(mindexs)
+function filter_messages(ms::Vector{<:MessageIndex}; query...)
     for (k, v) in query
         ms = filter_messages(ms, string(k), v)
     end


### PR DESCRIPTION
This `deepcopy` in `filter_messages` is very expensive. And it doesn't appear to be needed, as `filter` doesn't alter the original object anyway.

The improvement in compile time is over 2 seconds for loading a .grib Raster in Rasters.jl

